### PR TITLE
LUT-27728 : workflow_context.xml is not loaded during announce site construction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,13 @@
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>plugin-announce</artifactId>
             <version>[2.0.2,)</version>
+            <type>lutece-plugin</type>
         </dependency>
         <dependency>
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>plugin-workflow</artifactId>
-            <version>[5.3.0-SNAPSHOT,)</version>
+            <version>[6.0.0-SNAPSHOT,)</version>
+            <type>lutece-plugin</type>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
workflow_context.xml is not loaded during announce site construction causing a NoSuchBeanDefinitionException error for Beans that are declared in this file